### PR TITLE
Cleaned up bad html in all files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ DataProcessing_Media/
 General_Media/
 MethodBuilding_Media/
 SystemTab_Media/
+Tuning/
 Xfer/

--- a/DataProcessingIntro.html
+++ b/DataProcessingIntro.html
@@ -100,14 +100,14 @@
 	immediately after acquisition.  This is done by including the desired data processing method within 
 	the corresponding line of the <a target="_blank" href="AcquisitionQueueUtilization.html">Acquisition Queue</a>.</p>
 	
-	<a class="content_media"><video src="DataProcessing_Media/Overview/ProcessSingleSampleViaAcquisitionQueue_CT5.31.16.mp4" controls></a>
+	<video class="content_media" src="DataProcessing_Media/Overview/ProcessSingleSampleViaAcquisitionQueue_CT5.31.16.mp4" controls></video>
 	
 	<p class="content_text">To save time multiple sample acquisitions can be assigned to a single DP method 
 	using a single operation.  This is done through the use of the Fill command.  Highlight and right click 
 	all cells which will be processed with the same data processing method then select the
 	desired data processing method.</p>
 	
-	<a class="content_media"><video src="DataProcessing_Media/Overview/ProcessMultiSamplesViaAcquisitionQueue_CT5.31.16.mp4" controls></a>
+	<video class="content_media" src="DataProcessing_Media/Overview/ProcessMultiSamplesViaAcquisitionQueue_CT5.31.16.mp4" controls></video>
 	
 	<h3>Sample Processing: Acquired Samples</h3>
 	<p class="content_text">Additionally, samples can be processed from Acquired Samples 
@@ -118,7 +118,7 @@
 	Finally, select the Data Processing method.  While a sample is being processed it 
 	will have a gear overlaid on its icon and it cannot be reviewed until processing is completed.</p>
 	
-	<a class="content_media"><video src="DataProcessing_Media/Overview/ProcessFromAcquiredSamples_CT5.31.16.mp4" controls></a>
+	<video class="content_media" src="DataProcessing_Media/Overview/ProcessFromAcquiredSamples_CT5.31.16.mp4" controls></video>
 	
 	<h3>Monitoring Data Processing Jobs</h3>
 	<p class="content_text">The status of a series of data processing jobs can be monitored and edited 
@@ -136,13 +136,13 @@
 	from that data processing iteration.  This includes all manual changes for example, analyte ID changes, defining 
 	a group label, or altering the Quant mass.</p>
 	
-	<a class="content_media"><video src="DataProcessing_Media/Overview/SelectDPResult_DPIteration_CT5.31.16.mp4" controls></a>
+	<video class="content_media" src="DataProcessing_Media/Overview/SelectDPResult_DPIteration_CT5.31.16.mp4" controls></video>
 	
 	<p class="content_text">To save a historical copy of a data processing method, right click within the desired 
 	DP method and select “Save As”.  You will then be prompted to define the name and location of the selected 
 	DP method.</p>
 		
-	<a class="content_media"><video src="DataProcessing_Media/Overview/SelectDPResult_SaveMethod_CT5.31.16.mp4" controls></a>
+	<video class="content_media" src="DataProcessing_Media/Overview/SelectDPResult_SaveMethod_CT5.31.16.mp4" controls></video>
 	
 </body> 
 </html>

--- a/DataProcessing_MonitorQueue.html
+++ b/DataProcessing_MonitorQueue.html
@@ -19,7 +19,7 @@
 	particular data processing job up or down the sequence of DP jobs.  Lastly, it 
 	illustrates how to remove a series data processing jobs from the queue.</p>
 	
-	<class="content_media" video src="DataProcessing_Media/Overview/DPQueueMonitor_CT5.31.16.mp4" controls></video>
+	<video class="content_media"  src="DataProcessing_Media/Overview/DPQueueMonitor_CT5.31.16.mp4" controls></video>
 
 </body> 
 </html>

--- a/LibrarySearchOptions_SpectralSimilarity.html
+++ b/LibrarySearchOptions_SpectralSimilarity.html
@@ -14,14 +14,13 @@
 	<h3>Procedure</h3>
 	<ol>
 		<li class="content_text"><strong>Enable Spectral Similarity Search</strong>
-			<p><video src="DataProcessing_Media/LibrarySearchOptions/SpectralSimilarity/EnableSpectralSimilaritySearch_CT5.31.16.mp4" controls></a></p>
-			<i>Enabling Spectral Similarity Searching</i>
+			<video class="content_media" src="DataProcessing_Media/LibrarySearchOptions/SpectralSimilarity/EnableSpectralSimilaritySearch_CT5.31.16.mp4" controls></video>
+			<i class="caption_text">Enabling Spectral Similarity Searching</i>
 		</li>
 		
 		<li class="content_text"><strong>Spectral Similarity Search Parameters</strong>
 		<img class="content_media" src="DataProcessing_Media/LibrarySearchOptions/SpectralSimilarity/SpectralSimilarity_LibrarySearcing_CT5.31.16.png"/>
-		<i>Spectral Similarity Searching Parameters for 1D & GCxGC Samples</i>
-		<p></p>
+		<i class="caption_text">Spectral Similarity Searching Parameters for 1D & GCxGC Samples</i>
 		
 		<ul>
 			<li class="content_text"><strong>Maximum Results</strong>: Defines the maximum number of library hits ChromaTOF will 
@@ -82,11 +81,11 @@
 		
 		<li class="content_text"><strong>Processing a Sample with Spectral Similarity Searching Enabled</strong>
 		
-		<p><video src="DataProcessing_Media/LibrarySearchOptions/SpectralSimilarity/1D_PF_SpectralSimilarity_CT5.31.16.mp4" controls></a></p>
-		<i>Processing a 1D Sample with Spectral Similarity Searching Enabled</i>
+		<video class="content_media" src="DataProcessing_Media/LibrarySearchOptions/SpectralSimilarity/1D_PF_SpectralSimilarity_CT5.31.16.mp4" controls></video>
+		<i class="caption_text">Processing a 1D Sample with Spectral Similarity Searching Enabled</i>
 		
-		<p><video src="DataProcessing_Media/LibrarySearchOptions/SpectralSimilarity/GCxGC_PF_SpectralSimilarity_CT5.31.16.mp4" controls></a></p>
-		<i>Processing a 1D Sample with Spectral Similarity Searching Enabled</i>
+		<video class="content_media" src="DataProcessing_Media/LibrarySearchOptions/SpectralSimilarity/GCxGC_PF_SpectralSimilarity_CT5.31.16.mp4" controls></video>
+		<i class="caption_text">Processing a 1D Sample with Spectral Similarity Searching Enabled</i>
 		</li>
 		
 	</ol>

--- a/MSMethodsIonSourceParameters.html
+++ b/MSMethodsIonSourceParameters.html
@@ -13,11 +13,29 @@
 	<h3>Ion Source Parameters</h1>
 	
 	<ul>
-		<li class="content_text"><strong>Emission current</strong>: The electrical current produced by electron emissions from the filament</li>
-		<li class="content_text"><strong>Ion source temperature</strong>: The temperature of the ion source</li>
-		<li class="content_text"><strong>Electron energy</strong>: The energy electrons have as they enter the ionization chamber</li>
-		<li class="content_text"><strong>Wait to Confirm</strong>: Data acquisition will wait for the values specified in the grid to be achieved before continuing.</li>
-		<li class="content_text"><strong>Load</strong>: Select Load to choose an MS method and use its applicable settings.</li>
+		<li class="content_text"><strong>Emission current</strong>: The electrical current produced by 
+		electron emissions from the filament, this value can be set for 0.5 – 5.0 mA (default setting 1mA).
+		<p>As emission current increases the signal and linear range also increase, but the resolution will 
+		suffer.</p>
+		<p>When emission current is decreased, the signal intensity will also decrease.  Running at a lower 
+		emission current could help for applications with higher concentration samples.  The 5 order linear 
+		dynamic range can shift up roughly half an order of concentration running at lower emission current; 
+		saturating at higher concentrations at the cost of higher detection limit.</p></li>
+		
+		<li class="content_text"><strong>Ion source temperature</strong>: The temperature of the ion source.  
+		The value can be set between 100˚C - 300˚C</li>
+		
+		<li class="content_text"><strong>Electron energy</strong>: The energy electrons have as they enter the 
+		ionization chamber.  The electron energy can be set from 40eV to 200eV, the default setting is 70eV.
+		It is recommended to use the default setting because nearly all commercially available spectral libraries 
+		are acquired at 70ev.</li>
+		
+		<li class="content_text"><strong>Wait to Confirm</strong>: Data acquisition will wait for the values 
+		specified in the grid to be achieved before continuing.</li>
+		
+		<li class="content_text"><strong>Load</strong>: Select Load to choose an MS method and use its 
+		applicable settings.</li>
+		
 		<li class="content_text"><strong>Reset</strong>: Select Reset to revert to default values.</li>
 	</ul>
 	

--- a/MethodBuildingOverview.html
+++ b/MethodBuildingOverview.html
@@ -18,30 +18,30 @@
 	a description of the function of each.</p>
 	
 	<img class="content_media" src="MethodBuilding_Media/Overview/MethodHotButtons_CT5.31.16.png"/>
-	<i>An example of each of the tool bar buttons shown at the top of a method.</i>
+	<i class="caption_text">An example of each of the tool bar buttons shown at the top of a method.</i>
 	
 	<ul>
 		<li class="content_text"><strong>Create New Method</strong>
-		<p></p>
+		
 		<ul>
 			<li class="content_text"><img src="MethodBuilding_Media/Overview/CreateNewHotButton_CT5.31.16.png"/> <strong>Using Method tool bar Button</strong>
 			<p>Select Methods on the ribbon bar, and then select the desired method from the selection that appears.  In the method’s toolbar, 
 			select Create New.</p>
-			<p><video src="MethodBuilding_Media/Overview/CreateNewMethodViaHotButton_CT5.31.16.mp4" controls></video></p>
-			<i>Creating a new method using the Create New button.</i>	
+			<video class="content_media" src="MethodBuilding_Media/Overview/CreateNewMethodViaHotButton_CT5.31.16.mp4" controls></video>
+			<i class="caption_text">Creating a new method using the Create New button.</i>	
 			</li>
 			
 			<li class="content_text"><strong>From the Database Manager</strong>
 			<p>Alternatively, methods can be created from the data base manager.</p>
-			<p><video src="MethodBuilding_Media/Overview/CreateNewMethodViaDBManager_CT5.31.16.mp4" controls></video></p>
-			<i>Creating a new method using the Database manager.</i>	
+			<video class="content_media" src="MethodBuilding_Media/Overview/CreateNewMethodViaDBManager_CT5.31.16.mp4" controls></video>
+			<i class="caption_text">Creating a new method using the Database manager.</i>	
 			</li>
 		</ul>
 		</li>
 			
 		<li class="content_text"><img src="MethodBuilding_Media/Overview/OpenHotButton_CT5.31.16.png"/> <strong>Open an existing method</strong>
-		<p><video src="MethodBuilding_Media/Overview/OpenExistingMethod_CT5.31.16.mp4" controls></video></p>
-		<i>Opening an existing method.</i>
+		<video class="content_media" src="MethodBuilding_Media/Overview/OpenExistingMethod_CT5.31.16.mp4" controls></video>
+		<i class="caption_text">Opening an existing method.</i>
 		</li>
 			
 		<li class="content_text"><img src="MethodBuilding_Media/Overview/SaveHotButton_CT5.31.16.png"/> <strong>Save</strong>
@@ -61,22 +61,22 @@
 		record of all the acquisition methods for each acquired sample.  These records do not change 
 		even if the current version of the method is altered.  To open an editable version of the 
 		method click the open method button and select it.</p>
-		<p><video src="MethodBuilding_Media/Overview/AutoSelect_AcquiredSamples_CT5.31.16.mp4" controls></video></p>
-		<i>Auto Select behavior when within Acquired Samples</i>
+		<video class="content_media" src="MethodBuilding_Media/Overview/AutoSelect_AcquiredSamples_CT5.31.16.mp4" controls></video>
+		<i class="caption_text">Auto Select behavior when within Acquired Samples</i>
 		
 		<p>If a method is visible when viewing the Acquisition Queue and Auto Select is enabled, 
 		an editable version of the method selected in the corresponding row in the acquisition 
 		queue will automatically be shown.  This will automatically updates as different rows in 
 		the acquisition queue are selected.</p>
-		<p><video src="MethodBuilding_Media/Overview/AutoSelect_AcquisitionQueue_CT5.31.16.mp4" controls></video></p>
-		<i>Auto Select behavior when within the Acquisition Queue</i>
+		<video class="content_media" src="MethodBuilding_Media/Overview/AutoSelect_AcquisitionQueue_CT5.31.16.mp4" controls></video>
+		<i class="caption_text">Auto Select behavior when within the Acquisition Queue</i>
 		
 		</li>
 			
 		<li><strong>Comparing Methods Side-by-Side</strong>
 		<p>Multiple methods of the same type can be view simultaneously by creating additional views.</p>
-		<p><video src="MethodBuilding_Media/Overview/ComparingMethods_CT5.31.16.mp4" controls></video></p>
-		<i>Creating multiple views of the same method type</i>
+		<video class="content_media" src="MethodBuilding_Media/Overview/ComparingMethods_CT5.31.16.mp4" controls></video>
+		<i class="caption_text">Creating multiple views of the same method type</i>
 		</li>
 		
 	</ul>

--- a/PeakFinding.html
+++ b/PeakFinding.html
@@ -28,19 +28,19 @@
 			and other peak metrics.  In the GCxGC video, the spectral match required to combine 
 			subpeaks is set to 500.</p>
 			
-			<p><video src="DataProcessing_Media/PeakFinding/1D_CreatePFMethod_CT5.31.16.mp4" controls></a></p>
-			<i>Creating a 1D PF Data Processing Method</i>
+			<video class="content_media" src="DataProcessing_Media/PeakFinding/1D_CreatePFMethod_CT5.31.16.mp4" controls></video>
+			<i class="caption_text">Creating a 1D PF Data Processing Method</i>
 			
-			<p><video src="DataProcessing_Media/PeakFinding/GCxGC_CreatePFMethod_CT5.31.16.mp4" controls></a></p>
-			<i>Creating a GCxGC PF Data Processing Method</i>
+			<video class="content_media" src="DataProcessing_Media/PeakFinding/GCxGC_CreatePFMethod_CT5.31.16.mp4" controls></video>
+			<i class="caption_text">Creating a GCxGC PF Data Processing Method</i>
 		</li>
 		
 		<li class="content_text"><strong>Peak Finding Parameters</strong>
 
 		<img class="content_media" src="DataProcessing_Media/PeakFinding/PeakFindingParameters_CT.5.31.16.png"/>
-		<i>Peak Finding Parameters for 1D & GCxGC Samples</i>
+		<i class="caption_text">Peak Finding Parameters for 1D & GCxGC Samples</i>
 		
-		<p></p>
+		
 		
 		<ul>
 			<li class="content_text"><strong>Peak Filtering Table</strong>: The Peak Filtering Table in the Peak Finding 
@@ -87,8 +87,8 @@
 		</ul>
 		
 		<img class="content_media" src="DataProcessing_Media/PeakFinding/GCxGC_SubPeakCombining_CT.5.31.16.png"/>
-		<i>GCxGC Subpeak Combining Parameters</i>
-		<p></p>
+		<i class="caption_text">GCxGC Subpeak Combining Parameters</i>
+		
 		
 		<ul>
 			<li class="content_text"><strong>GCxGC Subpeak Combining</strong>: If GCxGC has been selected on the Peak Finding 
@@ -133,11 +133,11 @@
 			<p>It is often useful to utilize the <a target="_blank" href="DataProcessing_MonitorQueue.html">data processing 
 			monitor & queue</a> when processing using peak finding due to the processing times.</p>
 		
-		<p><video src="DataProcessing_Media/PeakFinding/1D_ProcessSample_CT5.31.16.mp4" controls></a></p>
-		<i>Processing a 1D sample with Peak Finding Only</i>
+		<video class="content_media" src="DataProcessing_Media/PeakFinding/1D_ProcessSample_CT5.31.16.mp4" controls></video>
+		<i class="caption_text">Processing a 1D sample with Peak Finding Only</i>
 			
-		<p><video src="DataProcessing_Media/PeakFinding/GCxGC_ProcessSample_CT5.31.16.mp4" controls></a></p>
-		<i>Processing a GCxGC sample with Peak Finding Only</i>
+		<video class="content_media" src="DataProcessing_Media/PeakFinding/GCxGC_ProcessSample_CT5.31.16.mp4" controls></video>
+		<i class="caption_text">Processing a GCxGC sample with Peak Finding Only</i>
 		
 		</li>
 		

--- a/QuantitationMethods.html
+++ b/QuantitationMethods.html
@@ -56,7 +56,7 @@
 			be sure the <a target="_blank" href="PeakFiltering_Group.html">group column</a> is visible.  
 			For each analyte to be quantitated add a label in the group column.  This will streamline 
 			searching, sorting, and filtering the analytes of interest in future steps.
-			<a class="content_media"><video src="QuantitationMethods_Media/PeakTable_AddingGroupLabels_Quant_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/PeakTable_AddingGroupLabels_Quant_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -72,7 +72,7 @@
 			Right click inside the Quantitation Table and select “Add Standard”. A window will pop up allowing 
 			you to browse through Acquired Samples, find and select the PQS. All analytes within the 
 			selected sample will appear in the Quantitation Table.
-			<a class="content_media"><video src="QuantitationMethods_Media/NewQuantMethod_AddStd_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/NewQuantMethod_AddStd_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -82,14 +82,14 @@
 			Sorting the table using the group column makes this step easier.  Highlight all analytes 
 			that were not grouped, right click within the Quantitation table and select 
 			Delete Selected Analytes.
-			<a class="content_media"><video src="QuantitationMethods_Media/DeleteSelectedAnalytes_QuantTbl_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/DeleteSelectedAnalytes_QuantTbl_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
 		<li class="content_text"><strong>Set Internal Standard(s) (optional)</strong>
 			<p>If your application utilizes a/an internal standard(s), then define which 
 			analytes are internal standards and which analyte(s) correspond to each internal standard.
-			<a class="content_media"><video src="QuantitationMethods_Media/SetIntStd_QuantTbl_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/SetIntStd_QuantTbl_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -98,7 +98,7 @@
 			The column where concentrations should be entered is in the far right of the Quantitation table, 
 			and the header matches the name of the sample. Note, you can copy (Ctrl + c) and paste (Ctrl + v)
 			from a spread sheet application to increase the efficiency of this step.
-			<a class="content_media"><video src="QuantitationMethods_Media/EnterPQSConc_QuantTbl_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/EnterPQSConc_QuantTbl_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -154,7 +154,7 @@
 			(calculation required) to <span class="red_txt">red</span> (calculating) to black (finished).
 			The processing time will be similar to the duration the PQS initailly took to process.  In
 			the video below the full processing time has been edited out for training purposes.
-			<a class="content_media"><video src="QuantitationMethods_Media/CalculateStandards_PQS_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/CalculateStandards_PQS_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -166,7 +166,7 @@
 			simultaneously holding the Shift key.  After doing so you'll notice new headers in the 
 			Quantitation and Standard tables corresponding to each sample added.  Be careful 
 			not to inadvertently add the PQS a second time.
-			<a class="content_media"><video src="QuantitationMethods_Media/AllAdditionalStds_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/AllAdditionalStds_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -191,7 +191,7 @@
 			50 pg internal standard concentration values are propagated by copy and pasting across all 
 			156 entries.  The PAH concentrations are entered using the fill command with the multiplier 
 			optional feature.  The video below demonstrates this procedure.
-			<a class="content_media"><video src="QuantitationMethods_Media/EnterAllConc_QuantTbl_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/EnterAllConc_QuantTbl_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -226,7 +226,7 @@
 			based upon the parameters set in the Quantitation table.  Finally, ChromaTOF is adding the 
 			appropriate data to generate each quantitation curve. This is carried out for each 
 			standard sample.
-			<a class="content_media"><video src="QuantitationMethods_Media/CalcStd_Quant_AllStds_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/CalcStd_Quant_AllStds_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -240,7 +240,7 @@
 			will be shown in the spectral window.  The integration markers can be 
 			<a target="_blank" href="Quant_ManuallyAdjustIntegrationMarkers.html">manually	changed</a>
 			to adjust calculated areas of standards.
-			<a class="content_media"><video src="QuantitationMethods_Media/Review_Quant_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/Review_Quant_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -249,7 +249,7 @@
 			back to <span class="green_txt">green</span>. Therefore, that analyte will require recalculation. You can save processing time by using "Calculate Analytes(s)" which will
 			only recalculate the selected analyte(s) rather then the entire standard when Calculate Standards is used. To highlight specific analyte rows,
 			right click on the corresponding row number while holding the Control key on your keyboard.
-			<a class="content_media"><video src="QuantitationMethods_Media/EditQuantTable_CalculateAnalyte_Quant_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/EditQuantTable_CalculateAnalyte_Quant_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -257,14 +257,14 @@
 			<p>Entire standard samples can be removed from the Quantitation method via the Quantitation table right click menu.
 			This will remove all data from the selected sample from the Quantitation method including all analytes and internal
 			internal standards.
-			<a class="content_media"><video src="QuantitationMethods_Media/Quant_RemoveStdSample_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/Quant_RemoveStdSample_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
 		<li class="content_text"><strong>Removing Individual Standard Analytes</strong>
 			<p>Alternatively, individual standard analytes can be removed from the Quantitation method via the Standard table right click menu.  
 			This will only remove the specifically selected analyte or internal standard from the Quantitation method.
-			<a class="content_media"><video src="QuantitationMethods_Media/Quant_RemoveIndividualStdAnalyte_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/Quant_RemoveIndividualStdAnalyte_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -275,7 +275,7 @@
 			You will notice that the data processing method origianally used to process the PQS has been populated into this method.  In this
 			example the Target Analyte Finding parameters.  To quantitate an unknown sample, process using this
 			Data Procesing method.
-			<a class="content_media"><video src="QuantitationMethods_Media/Quant_CreateDPMethod_CT5.02.00.mp4" controls></a>
+			<video class="content_media" src="QuantitationMethods_Media/Quant_CreateDPMethod_CT5.02.00.mp4" controls></video>
 			</p>
 		</li>
 		

--- a/ReferenceMethods.html
+++ b/ReferenceMethods.html
@@ -46,7 +46,7 @@
 			the group column. The group labels will be propigated to samples that are processed using
 			the reference method created from this reference standard. This will streamline searching, 
 			sorting, and filtering the analytes of interest in future steps.  
-			<a class="content_media"><video src="ReferenceMethods_Media/PeakTable_AddingGroupLabels_CT5.01.04.mp4" controls></a>
+			<video class="content_media" src="ReferenceMethods_Media/PeakTable_AddingGroupLabels_CT5.01.04.mp4" controls></video>
 			</p>
 		</li>
 			
@@ -63,7 +63,7 @@
 			the user to browse through Acquired Samples to select the reference standard. When the sample 
 			is found, click “Select”. All analytes within the selected sample will appear in the Reference 
 			Table.
-			<a class="content_media"><video src="ReferenceMethods_Media/NewMethod_AddStd_CT5.01.04.mp4" controls></a>
+			<video class="content_media" src="ReferenceMethods_Media/NewMethod_AddStd_CT5.01.04.mp4" controls></video>
 			</p>
 		</li>
 			
@@ -81,7 +81,7 @@
 			relevant to the analysis. Highlight all the peaks that were not assigned labels in the group 
 			column, right click, and select “Delete Selected Analytes”.  This will delete all of the selected 
 			peaks from the reference table, leaving only the target peaks.
-			<a class="content_media"><video src="ReferenceMethods_Media/DeleteAnalytesFromRefTable_CT5.01.04.mp4" controls></a>
+			<video class="content_media" src="ReferenceMethods_Media/DeleteAnalytesFromRefTable_CT5.01.04.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -143,7 +143,7 @@
 			text in the reference table will be <span class="green_txt">green</span>. While the standards are being calculated, the reference table information will be 
 			<span class="red_txt">red</span> which indicates that the operation is in progress. Once it has completed, the text will become black. This will require
 			a similar amount of time as the reference standard took to initially data process.
-			<a class="content_media"><video src="ReferenceMethods_Media/CalculateStandard_CT5.01.04.mp4" controls></a>
+			<video class="content_media" src="ReferenceMethods_Media/CalculateStandard_CT5.01.04.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -152,7 +152,7 @@
 			back to <span class="green_txt">green</span>. As a result, that analyte will require recalculation. You can save processing time by using "Calculate Analytes(s)" which will
 			only recalculate the selected analyte(s) rather then the entire standard when “Calculate Standard” is used. To highlight specific analyte rows,
 			right click on the corresponding row number while holding the Control key on your keyboard.
-			<a class="content_media"><video src="ReferenceMethods_Media/Edit_CalculateAnalyte_CT5.01.04.mp4" controls></a>
+			<video class="content_media" src="ReferenceMethods_Media/Edit_CalculateAnalyte_CT5.01.04.mp4" controls></video>
 			</p>
 		</li>
 		
@@ -160,7 +160,7 @@
 			<p>Now that the reference method has been successfully created, the next step involves incorporating 
 			it into a data processing method. Begin by creating and renaming a new data processing method. Next, 
 			select the “Quantitate Reference” tab, then enable and add the desired reference method.
-			<a class="content_media"><video src="ReferenceMethods_Media/CreateApplyReferenceDPMethod_CT5.01.04.mp4" controls></a>
+			<video class="content_media" src="ReferenceMethods_Media/CreateApplyReferenceDPMethod_CT5.01.04.mp4" controls></video>
 			</p>
 			
 			<p>After imbeding the refernece method into the data processing method, the data processing technique used to locate peaks in the reference sample 
@@ -180,7 +180,7 @@
 		<li class="content_text"><strong>Apply Reference Method</strong>
 			<p>To apply the Reference Method to an unknown sample simply process the sample with the data processing
 			method that is imbedded with the desired Reference method.
-			<a class="content_media"><video src="ReferenceMethods_Media/ApplyReferenceMethod_CT5.01.04.mp4" controls></a>
+			<video class="content_media" src="ReferenceMethods_Media/ApplyReferenceMethod_CT5.01.04.mp4" controls></video>
 			</p>
 		</li>
 		

--- a/System_ColumnSetup.html
+++ b/System_ColumnSetup.html
@@ -34,10 +34,10 @@
 	
 	<h3>Accessing the Column Configuration</h3>
 	<video class="content_media" src="SystemTab_Media/GlobalColumnConfiguration/AccessingGCC_1DSystem_CT5.31.16.mp4" controls></video>
-	<i>Accessing the Column Configuration on a 1D System</i>
+	<i class="caption_text">Accessing the Column Configuration on a 1D System</i>
 	
 	<video class="content_media" src="SystemTab_Media/GlobalColumnConfiguration/AccessingGCC_GCxGCSystem_CT5.31.16.mp4" controls></video>
-	<i>Accessing the Column Configuration on a GCxGC System</i>
+	<i class="caption_text">Accessing the Column Configuration on a GCxGC System</i>
 	
 	<h3>Load the Column Configuration from a GC Method</h3>
 	<video class="content_media" src="SystemTab_Media/GlobalColumnConfiguration/UpdateGCCFromMethod_CT5.31.16.mp4" controls></video>

--- a/TAF_test.html
+++ b/TAF_test.html
@@ -24,7 +24,7 @@
 	<ol>
 		<li class="content_text"><strong>Create New TAF DP Method</strong>
 			<video class="content_media" src="DataProcessing_Media/TAF/1D_CreateDPMethod_CT5.31.16.mp4" controls></video>
-			<i class="caption_text">Creating a 1D TAF Data Processing Method</i>
+			<i class="caption_text">Creating a 1D TAF Data Processing Method</li>
 			
 			<video class="content_media" src="DataProcessing_Media/TAF/GCxGC_CreateDPMethod_CT5.31.16.mp4" controls></video>
 			<i class="caption_text">Creating a GCxGC TAF Data Processing Method</i>

--- a/TrainingStyle.css
+++ b/TrainingStyle.css
@@ -17,6 +17,11 @@ li.content_text {
 	padding-bottom: 15px;
 }
 
+i.caption_text {
+	display: block;
+	padding-bottom: 20px;
+}
+
 .content_media{
 	display: block;
 	padding-top: 7.5px;

--- a/TuningOverview.html
+++ b/TuningOverview.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link href="TrainingStyle.css" type="text/css" rel="stylesheet">
+  <title>LECO Pegasus BT Self Guided Training</title>
+</head>
+<body>
+	<img id="banner_image" src="General_Media/LECO Banner.PNG"/>
+	<h1>Tuning Overview</h1>
+	
+	<h3>Introduction</h3>
+	<p class="content_text">Under Construction</p>
+	
+	<video class="content_media" poster="Tuning/SAF_CT5.31.16.png" controls>
+		<source src="Tuning/SAF_CT5.31.16.mp4" type="video/mp4">
+	</video>
+	
+</body> 
+</html>


### PR DESCRIPTION
Used grep & sed linux commands to fix the following "bad" html code: 
<a><video></video></a>
<p></p> to manage spacing, instead create a new css class (i.caption_text) to handle this a bit more elegantly.